### PR TITLE
only add hotkeys once to a cheatsheet

### DIFF
--- a/src/cheatsheet.lua
+++ b/src/cheatsheet.lua
@@ -105,8 +105,8 @@ function Cheatsheet._createShortcutBlocks(shortcutList)
 
         local used_shortcuts = {}
         for _, shortcut in pairs(shortcuts) do
-            if used_shortcuts[shortcut.key] == nil then
-                used_shortcuts[shortcut.key] = true
+            if used_shortcuts[shortcut.hotkey] == nil then
+                used_shortcuts[shortcut.hotkey] = true
                 table.insert(block, { name = shortcut.name, hotkey = shortcut.hotkey })
             end
         end

--- a/src/cheatsheet.lua
+++ b/src/cheatsheet.lua
@@ -103,8 +103,12 @@ function Cheatsheet._createShortcutBlocks(shortcutList)
             return string.reverse(a.hotkey) < string.reverse(b.hotkey)
         end)
 
+        local used_shortcuts = {}
         for _, shortcut in pairs(shortcuts) do
-            table.insert(block, { name = shortcut.name, hotkey = shortcut.hotkey })
+            if used_shortcuts[shortcut.key] == nil then
+                used_shortcuts[shortcut.key] = true
+                table.insert(block, { name = shortcut.name, hotkey = shortcut.hotkey })
+            end
         end
 
         table.insert(shortcutBlocks, { shortcuts = block })

--- a/src/init.lua
+++ b/src/init.lua
@@ -44,7 +44,7 @@ local Ki = {}
 Ki.__index = Ki
 
 Ki.name = "Ki"
-Ki.version = "1.5.0"
+Ki.version = "1.6.0"
 Ki.author = "Andrew Kwon"
 Ki.homepage = "https://github.com/andweeb/ki"
 Ki.license = "MIT - https://opensource.org/licenses/MIT"


### PR DESCRIPTION
This fixes the cheatsheet preview to only display shortcuts once.